### PR TITLE
Add Deployment Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ $ yarn watch
 
 ## Deployment
 
-To deploy a new version of this GitHub Action, create [a new release](https://github.com/airplanedev/action-build-and-deploy/releases/new).
-
-Releases are tagged using [semver](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). In the release, set the tag version and release title to your new version. Make sure to use a `v` prefix, such as `v0.5.4`. Add a description of the changes with links to previous PRs ([examples](https://github.com/airplanedev/action-build-and-deploy/releases)).
+To deploy a new version of this GitHub Action, create [a new release](https://github.com/airplanedev/action-build-and-deploy/releases/new). Releases are tagged using [semver](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). In the release, set the tag version and release title to your new version. Make sure to use a `v` prefix, such as `v0.5.4`. Add a description of the changes with links to previous PRs ([examples](https://github.com/airplanedev/action-build-and-deploy/releases)).
 
 After creating the release, update the latest major version to point to this new tag. Consumers of this Action will reference the major version so that they always get the latest minor updates. If you are releasing a new major version, make sure to update the README example above.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,25 @@ On every commit, your Airplane tasks will be uploaded. You'll be able to referen
 $ yarn install
 # GitHub Actions are run directly from a repo. Therefore, you need to compile and
 # package all dependencies in the repo itself. Therefore, leave this running:
-$ yarn build --watch
+$ yarn watch
+```
+
+## Deployment
+
+To deploy a new version of this GitHub Action, create [a new release](https://github.com/airplanedev/action-build-and-deploy/releases/new).
+
+Releases are tagged using [semver](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). In the release, set the tag version and release title to the version you are releasing. Make sure to add a `v` prefix, such as `v0.5.3`. Add a description of the changes, with links to previous PRs ([examples](https://github.com/airplanedev/action-build-and-deploy/releases)).
+
+After creating the release, update the latest major version to point to this new tag. Consumers of this Action will reference the major version so that they always get the latest minor updates. If you are releasing a new major version, make sure to update the README example above.
+
+```sh
+git fetch --tags
+# Checkout the tag you just released.
+git checkout v0.5.4
+# Alias it with the major version.
+git tag -f v0.5
+# --force for when the major tag already exists
+git push origin v0.5 --force
 ```
 
 ## Related Resources

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.1.1
+        uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Upload Airplane Tasks
-        uses: airplanedev/action-build-and-deploy@main
+        uses: airplanedev/action-build-and-deploy@v0.1
         with:
           # TODO(you): get an API key the Airplane team, then store it as a GitHub Secret:
           # https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
@@ -80,7 +80,7 @@ $ yarn watch
 
 To deploy a new version of this GitHub Action, create [a new release](https://github.com/airplanedev/action-build-and-deploy/releases/new).
 
-Releases are tagged using [semver](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). In the release, set the tag version and release title to the version you are releasing. Make sure to add a `v` prefix, such as `v0.5.3`. Add a description of the changes, with links to previous PRs ([examples](https://github.com/airplanedev/action-build-and-deploy/releases)).
+Releases are tagged using [semver](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning). In the release, set the tag version and release title to your new version. Make sure to use a `v` prefix, such as `v0.5.4`. Add a description of the changes with links to previous PRs ([examples](https://github.com/airplanedev/action-build-and-deploy/releases)).
 
 After creating the release, update the latest major version to point to this new tag. Consumers of this Action will reference the major version so that they always get the latest minor updates. If you are releasing a new major version, make sure to update the README example above.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ git fetch --tags
 git checkout v0.5.4
 # Alias it with the major version.
 git tag -f v0.5
-# --force for when the major tag already exists
+# Push to GitHub, --force for when the major tag already exists.
 git push origin v0.5 --force
 ```
 


### PR DESCRIPTION
I've added a `v0.1` tag that points to the latest `v0.1.x` release. This is what GitHub recommends and what most other Actions will do. I've updated the README to include deployment instructions on this.